### PR TITLE
Updated so the compress can be overwritten by the _config.yml

### DIFF
--- a/lib/jekyll-less.rb
+++ b/lib/jekyll-less.rb
@@ -46,7 +46,7 @@ module Jekyll
 
       # Initialize options from site config.
       def initialize(config = {})
-        @options = {"compress" => true}.merge(config["less"] ||= {})
+        @options = config["less"] ||= {"compress" => true}
       end
 
       # Jekyll will have already added the *.less files as Jekyll::StaticFile


### PR DESCRIPTION
Was having trouble toggling compression between dev and production, so threw together a little patch.  The previous code did not allow over-writing from the config, even though it looked like it was trying to let you.  
