### PR TITLE
Include `therubyracer` as a runtime dependency

### DIFF
--- a/jekyll-less.gemspec
+++ b/jekyll-less.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('jekyll', [">= 0.10.0"])
   s.add_runtime_dependency('less', [">= 2.0.5"])
+  s.add_runtime_dependency('therubyracer', [">= 0.12.1"])
 end


### PR DESCRIPTION
This plugin didn't work out-of-the box for me. It complained about a missing gem (`therubyracer`). I've included it as a runtime dependency in the gemspec.

Note: I'm not sure about the version. I just copied the version that resulted in typing `gem install therubyracer`. I'm also not sure how to test this change.
